### PR TITLE
Fix SMA200 line visibility

### DIFF
--- a/src/components/TradingDashboard.tsx
+++ b/src/components/TradingDashboard.tsx
@@ -67,7 +67,12 @@ const TradingDashboard = () => {
   const { data: tvlData, loading: tvlLoading, error: tvlError } = useBitcoinTVLData();
 
   // Configuration
-  const LOOKBACK_DAYS = 201;
+  // Number of historical candles to fetch.
+  // This value needs to be larger than the longest moving average period
+  // plus the largest time range we want to display so that long SMAs like
+  // the 200-day average have enough data for the full chart window.
+  // Using one year of data provides enough history for all views.
+  const LOOKBACK_DAYS = 365;
   const SMA_PERIODS = [5, 20, 50, 100, 200];
   const EMA_PERIODS = [5, 20, 50, 100, 200];
   const BB_PERIOD = 20;


### PR DESCRIPTION
## Summary
- fetch more historical data so long-term moving averages like SMA200 have enough data for the full chart window

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688021952e58832dab8c919f0fff40d1