### PR TITLE
Add AI market analysis section

### DIFF
--- a/src/components/AIMarketAnalysisSection.tsx
+++ b/src/components/AIMarketAnalysisSection.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AlertTriangle, Brain, Clock } from 'lucide-react';
+import { useAIMarketAnalysis, MarketIndicators } from '@/hooks/useAIMarketAnalysis';
+
+interface Props {
+  symbol: string;
+  indicators: MarketIndicators;
+}
+
+const AIMarketAnalysisSection: React.FC<Props> = ({ symbol, indicators }) => {
+  const { data, loading, error } = useAIMarketAnalysis(symbol, indicators);
+
+  const formatTimeAgo = (dateString: string) => {
+    const now = new Date();
+    const created = new Date(dateString);
+    const diffHours = Math.floor((now.getTime() - created.getTime()) / (1000 * 60 * 60));
+    if (diffHours < 1) return 'Just now';
+    if (diffHours === 1) return '1 hour ago';
+    if (diffHours < 24) return `${diffHours} hours ago`;
+    return `${Math.floor(diffHours / 24)} days ago`;
+  };
+
+  return (
+    <Card className="my-6">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Brain className="h-5 w-5 text-primary" />
+          AI Market Analysis
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : error ? (
+          <div className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <span className="text-sm">{error}</span>
+          </div>
+        ) : data ? (
+          <div className="space-y-4">
+            <div className="bg-muted/50 rounded-lg p-3">
+              <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                {data.analysis}
+              </p>
+            </div>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              <span>Generated {formatTimeAgo(data.created_at)}</span>
+            </div>
+          </div>
+        ) : (
+          <div className="text-center py-4 text-muted-foreground">
+            No AI analysis available
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AIMarketAnalysisSection;

--- a/src/components/TradingDashboard.tsx
+++ b/src/components/TradingDashboard.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, TrendingUp, TrendingDown, Activity, BookOpen, Brain, Frown, Smile, Meh, BarChart3, TrendingUp as StatisticsIcon, Bot, ExternalLink, AlertCircle } from 'lucide-react';
 import AIRecommendationSection from './AIRecommendationSection';
+import AIMarketAnalysisSection from './AIMarketAnalysisSection';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import LearnSection from './LearnSection';
 import { Tooltip as UITooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -1776,6 +1777,25 @@ const TradingDashboard = () => {
                 </table>
               </div>
             </Card>
+
+            {/* AI Market Analysis Section */}
+            <AIMarketAnalysisSection
+              symbol={symbol}
+              indicators={{
+                price: indicators.currentPrice,
+                sma20: indicators.sma20,
+                sma50: indicators.sma50,
+                sma200: indicators.sma200,
+                ema20: indicators.ema20,
+                ema50: indicators.ema50,
+                ema200: indicators.ema200,
+                rsi: indicators.rsi,
+                priceZScore: indicators.priceZScore,
+                volumeZScore: indicators.volumeZScore,
+                rsiZScore: indicators.rsiZScore,
+                atrZScore: indicators.atrZScore,
+              }}
+            />
           </>
         ) : currentView === 'technical' ? (
           <>

--- a/src/hooks/useAIMarketAnalysis.tsx
+++ b/src/hooks/useAIMarketAnalysis.tsx
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface MarketIndicators {
+  price?: number;
+  sma20?: number;
+  sma50?: number;
+  sma200?: number;
+  ema20?: number;
+  ema50?: number;
+  ema200?: number;
+  rsi?: number;
+  priceZScore?: number;
+  volumeZScore?: number;
+  rsiZScore?: number;
+  atrZScore?: number;
+}
+
+interface AIMarketAnalysisData {
+  id: string;
+  ticker: string;
+  analysis: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export const useAIMarketAnalysis = (symbol: string, indicators: MarketIndicators) => {
+  const [data, setData] = useState<AIMarketAnalysisData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAnalysis = async () => {
+    if (!symbol) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { data: response, error } = await supabase.functions.invoke('fetch-market-analysis', {
+        body: {
+          ticker: symbol,
+          indicators,
+        },
+      });
+
+      if (error) {
+        console.error('Error calling AI market analysis function:', error);
+        setError('Failed to fetch AI analysis');
+        return;
+      }
+
+      if (response?.error) {
+        console.error('AI market analysis API error:', response.error);
+        setError(response.error);
+        return;
+      }
+
+      if (response?.data) {
+        setData(response.data);
+      }
+    } catch (err) {
+      console.error('Error fetching AI market analysis:', err);
+      setError('Failed to fetch AI analysis');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAnalysis();
+    const interval = setInterval(fetchAnalysis, 60 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [symbol]);
+
+  return { data, loading, error, refetch: fetchAnalysis };
+};

--- a/supabase/functions/fetch-market-analysis/index.ts
+++ b/supabase/functions/fetch-market-analysis/index.ts
@@ -1,0 +1,115 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.52.0';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const isDev = Deno.env.get('NODE_ENV') === 'development';
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { ticker, indicators } = await req.json();
+
+    if (isDev) {
+      console.log(`Fetching AI market analysis for ${ticker}`);
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const { data: existing, error: fetchError } = await supabase
+      .from('ai_market_analyses')
+      .select('*')
+      .eq('ticker', ticker)
+      .gte('created_at', oneHourAgo.toISOString())
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    if (fetchError) {
+      console.error('Error fetching existing analysis:', fetchError);
+      throw new Error('Failed to check existing analyses');
+    }
+
+    if (existing && existing.length > 0) {
+      if (isDev) {
+        console.log(`Returning cached AI market analysis for ${ticker}`);
+      }
+      return new Response(JSON.stringify({ data: existing[0], fromCache: true }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const nvidiaApiKey = Deno.env.get('NVIDIA_API_KEY');
+    if (!nvidiaApiKey) {
+      throw new Error('NVIDIA API key not configured');
+    }
+
+    const prompt = `Provide a concise summary of the current ${ticker} market based on these indicators:\n` +
+      `${JSON.stringify(indicators, null, 2)}\n` +
+      `Keep it under 200 words.`;
+
+    const response = await fetch('https://integrate.api.nvidia.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${nvidiaApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'writer/palmyra-fin-70b-32k',
+        messages: [
+          { role: 'system', content: 'You are an expert cryptocurrency market analyst.' },
+          { role: 'user', content: prompt }
+        ],
+        temperature: 0.2,
+        top_p: 0.7,
+        max_tokens: 512,
+      }),
+    });
+
+    if (!response.ok) {
+      console.error('NVIDIA API error:', response.status, response.statusText);
+      throw new Error(`NVIDIA API error: ${response.status}`);
+    }
+
+    const aiResponse = await response.json();
+    const analysisText = aiResponse.choices[0].message.content;
+
+    const { data: newAnalysis, error: insertError } = await supabase
+      .from('ai_market_analyses')
+      .insert({ ticker, analysis: analysisText })
+      .select()
+      .single();
+
+    if (insertError) {
+      console.error('Error storing analysis:', insertError);
+      return new Response(JSON.stringify({
+        data: { ticker, analysis: analysisText, created_at: new Date().toISOString() },
+        fromCache: false,
+        storageError: true,
+      }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+
+    if (isDev) {
+      console.log(`Generated and stored new AI market analysis for ${ticker}`);
+    }
+
+    return new Response(JSON.stringify({ data: newAnalysis, fromCache: false }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+
+  } catch (error) {
+    console.error('Error in fetch-market-analysis function:', error);
+    return new Response(JSON.stringify({ error: error.message || 'Failed to generate AI market analysis' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20250724173500-create-ai-market-analyses.sql
+++ b/supabase/migrations/20250724173500-create-ai-market-analyses.sql
@@ -1,0 +1,17 @@
+CREATE TABLE public.ai_market_analyses (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  ticker TEXT NOT NULL,
+  analysis TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.ai_market_analyses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow read access to ai_market_analyses" ON public.ai_market_analyses
+  FOR SELECT USING (true);
+
+CREATE POLICY "Allow service role to manage ai_market_analyses" ON public.ai_market_analyses
+  FOR ALL USING (auth.role() = 'service_role'::text);
+
+CREATE INDEX idx_ai_market_analyses_ticker_created ON public.ai_market_analyses (ticker, created_at DESC);


### PR DESCRIPTION
## Summary
- create Supabase function for hourly market analysis
- add migration for ai_market_analyses table
- create hook and component for AI market analysis display
- show market analysis in overview below moving averages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6882a64db770832d844c9f283440ab30