### PR TITLE
Add missing indicator recommendations

### DIFF
--- a/src/components/OBVChart.tsx
+++ b/src/components/OBVChart.tsx
@@ -37,6 +37,14 @@ const OBVChart: React.FC<OBVChartProps> = ({ chartData, chartHeight, formatDate,
     return cov / denom;
   }, [chartData]);
 
+  const obvRecommendation = obvPriceCorrelation !== null
+    ? obvPriceCorrelation > 0.5
+      ? 'BUY'
+      : obvPriceCorrelation < -0.5
+        ? 'SELL'
+        : 'HOLD'
+    : 'HOLD';
+
   return (
     <Card className="p-6 shadow-card border-border">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-4">
@@ -50,6 +58,19 @@ const OBVChart: React.FC<OBVChartProps> = ({ chartData, chartHeight, formatDate,
               <span className="text-muted-foreground">Correlation with Price: </span>
               <span className="font-semibold">{obvPriceCorrelation.toFixed(2)}</span>
             </p>
+          )}
+          {obvPriceCorrelation !== null && (
+            <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+              <div className="text-sm">
+                <span className="text-muted-foreground">Recommendation: </span>
+                <span className={`font-semibold ${
+                  obvRecommendation === 'BUY' ? 'text-green-600' :
+                  obvRecommendation === 'SELL' ? 'text-red-600' : 'text-yellow-600'
+                }`}>
+                  {obvRecommendation}
+                </span>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/src/components/StochasticChart.tsx
+++ b/src/components/StochasticChart.tsx
@@ -9,6 +9,14 @@ interface StochasticChartProps {
 }
 
 const StochasticChart: React.FC<StochasticChartProps> = ({ chartData, chartHeight, formatDate }) => {
+  const latest = chartData.length > 0 ? chartData[chartData.length - 1] : null;
+  const stochK = latest?.stochK;
+  const stochD = latest?.stochD;
+  let recommendation = 'HOLD';
+  if (stochK !== undefined && stochD !== undefined) {
+    if (stochK < 20 && stochD < 20) recommendation = 'BUY';
+    else if (stochK > 80 && stochD > 80) recommendation = 'SELL';
+  }
   return (
     <Card className="p-6 shadow-card border-border">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-4">
@@ -17,6 +25,25 @@ const StochasticChart: React.FC<StochasticChartProps> = ({ chartData, chartHeigh
           <p className="text-sm text-muted-foreground">
             The Stochastic Oscillator compares a security's closing price to its price range over a given time period. The %K line represents the current position within the range, while %D is a smoothed version that acts as a signal line.
           </p>
+          {latest && stochK !== undefined && stochD !== undefined && (
+            <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+              <div className="text-sm">
+                <span className="text-muted-foreground">Current %K: </span>
+                <span className="font-semibold">{stochK.toFixed(2)}</span>
+                <span className="text-muted-foreground ml-4">%D: </span>
+                <span className="font-semibold">{stochD.toFixed(2)}</span>
+              </div>
+              <div className="text-sm mt-1">
+                <span className="text-muted-foreground">Recommendation: </span>
+                <span className={`font-semibold ${
+                  recommendation === 'BUY' ? 'text-green-600' :
+                  recommendation === 'SELL' ? 'text-red-600' : 'text-yellow-600'
+                }`}>
+                  {recommendation}
+                </span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
       <div className="bg-chart-bg rounded-lg p-4" style={{ height: chartHeight * 0.7 }}>

--- a/src/components/TradingDashboard.tsx
+++ b/src/components/TradingDashboard.tsx
@@ -1417,6 +1417,29 @@ const TradingDashboard = () => {
 
   const { chartData, indicators, cycles, cycleStrength, cycleProjections } = processedData;
 
+  const priceZRecommendation =
+    indicators.priceZScoreSignal === 'Extremely High' || indicators.priceZScoreSignal === 'High'
+      ? 'SELL'
+      : indicators.priceZScoreSignal === 'Low' || indicators.priceZScoreSignal === 'Extremely Low'
+        ? 'BUY'
+        : 'HOLD';
+
+  const volumeZRecommendation =
+    indicators.volumeZScoreSignal === 'Extremely High' || indicators.volumeZScoreSignal === 'High'
+      ? 'BUY'
+      : indicators.volumeZScoreSignal === 'Low' || indicators.volumeZScoreSignal === 'Extremely Low'
+        ? 'SELL'
+        : 'HOLD';
+
+  const adxRecommendation = indicators.adx !== null && indicators.adx !== undefined
+    ? indicators.adx > 25
+      ? 'STRONG TREND'
+      : indicators.adx < 20
+        ? 'WEAK TREND'
+        : 'MODERATE TREND'
+    : 'UNKNOWN';
+
+
   if (!indicators) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center p-6">
@@ -2077,6 +2100,19 @@ const TradingDashboard = () => {
             Shows how far price deviates from its 30‑day average. Values above 2 or
             below −2 highlight extreme conditions.
           </p>
+          <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+            <div className="text-sm">
+              <span className="text-muted-foreground">Current Z-Score: </span>
+              <span className="font-semibold">{indicators.priceZScore?.toFixed(2) ?? 'N/A'}</span>
+              <span className="text-muted-foreground ml-4">Recommendation: </span>
+              <span className={`font-semibold ${
+                priceZRecommendation === 'BUY' ? 'text-green-600' :
+                priceZRecommendation === 'SELL' ? 'text-red-600' : 'text-yellow-600'
+              }`}>
+                {priceZRecommendation}
+              </span>
+            </div>
+          </div>
           <div className="bg-chart-bg rounded-lg p-4" style={{ height: chartHeight * 0.7 }}>
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={filteredChartData}>
@@ -2114,11 +2150,24 @@ const TradingDashboard = () => {
                 className="scale-90"
               />
             </div>
-            <p className="text-sm text-muted-foreground mb-4">
-              Highlights how current trading volume compares to its 30‑day mean
-              to spot unusual market participation.
-            </p>
-            <div className="bg-chart-bg rounded-lg p-4" style={{ height: chartHeight * 0.7 }}>
+          <p className="text-sm text-muted-foreground mb-4">
+            Highlights how current trading volume compares to its 30‑day mean
+            to spot unusual market participation.
+          </p>
+          <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+            <div className="text-sm">
+              <span className="text-muted-foreground">Current Z-Score: </span>
+              <span className="font-semibold">{indicators.volumeZScore?.toFixed(2) ?? 'N/A'}</span>
+              <span className="text-muted-foreground ml-4">Recommendation: </span>
+              <span className={`font-semibold ${
+                volumeZRecommendation === 'BUY' ? 'text-green-600' :
+                volumeZRecommendation === 'SELL' ? 'text-red-600' : 'text-yellow-600'
+              }`}>
+                {volumeZRecommendation}
+              </span>
+            </div>
+          </div>
+          <div className="bg-chart-bg rounded-lg p-4" style={{ height: chartHeight * 0.7 }}>
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={filteredChartData}>
                   <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--chart-grid))" />
@@ -2178,6 +2227,19 @@ const TradingDashboard = () => {
               The Average Directional Index gauges how strong the current trend
               is, regardless of direction.
             </p>
+            <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+              <div className="text-sm">
+                <span className="text-muted-foreground">Current ADX: </span>
+                <span className="font-semibold">{indicators.adx?.toFixed(2) ?? 'N/A'}</span>
+                <span className="text-muted-foreground ml-4">Signal: </span>
+                <span className={`font-semibold ${
+                  adxRecommendation === 'STRONG TREND' ? 'text-green-600' :
+                  adxRecommendation === 'WEAK TREND' ? 'text-red-600' : 'text-yellow-600'
+                }`}>
+                  {adxRecommendation}
+                </span>
+              </div>
+            </div>
             <div className="bg-chart-bg rounded-lg p-4" style={{ height: chartHeight * 0.7 }}>
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={filteredChartData}>

--- a/src/components/WilliamsRChart.tsx
+++ b/src/components/WilliamsRChart.tsx
@@ -9,6 +9,12 @@ interface WilliamsRChartProps {
 }
 
 const WilliamsRChart: React.FC<WilliamsRChartProps> = ({ chartData, chartHeight, formatDate }) => {
+  const latest = chartData.length > 0 ? chartData[chartData.length - 1].williamsR : null;
+  let recommendation = 'HOLD';
+  if (latest !== null && latest !== undefined) {
+    if (latest < -80) recommendation = 'BUY';
+    else if (latest > -20) recommendation = 'SELL';
+  }
   return (
     <Card className="p-6 shadow-card border-border">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-4">
@@ -17,6 +23,23 @@ const WilliamsRChart: React.FC<WilliamsRChartProps> = ({ chartData, chartHeight,
           <p className="text-sm text-muted-foreground">
             The Williams %R oscillator highlights overbought and oversold levels. Values above -20 suggest overbought while below -80 indicate oversold conditions.
           </p>
+          {latest !== null && (
+            <div className="mt-3 p-3 bg-muted/50 rounded-lg">
+              <div className="text-sm">
+                <span className="text-muted-foreground">Current %R: </span>
+                <span className="font-semibold">{latest.toFixed(2)}</span>
+              </div>
+              <div className="text-sm mt-1">
+                <span className="text-muted-foreground">Recommendation: </span>
+                <span className={`font-semibold ${
+                  recommendation === 'BUY' ? 'text-green-600' :
+                  recommendation === 'SELL' ? 'text-red-600' : 'text-yellow-600'
+                }`}>
+                  {recommendation}
+                </span>
+              </div>
+            </div>
+          )}
         </div>
       </div>
       <div className="bg-chart-bg rounded-lg p-4" style={{ height: chartHeight * 0.7 }}>


### PR DESCRIPTION
## Summary
- show buy/sell signals on stochastic oscillator
- add OBV correlation recommendation
- display Z-score recommendations for price and volume
- show ADX trend strength signal
- highlight Williams %R recommendation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68857e65a608832da505cea2bcebd2e2