### PR TITLE
Add skull and crossbones emoji for death cross marker

### DIFF
--- a/src/components/TradingDashboard.tsx
+++ b/src/components/TradingDashboard.tsx
@@ -1664,7 +1664,7 @@ const TradingDashboard = () => {
                     {/* Golden Cross / Death Cross markers */}
                     {filteredChartData.map((d, idx) => {
                       if (!d.cross) return null;
-                      const emoji = d.cross === 'golden' ? '⭐️' : '💀';
+                      const emoji = d.cross === 'golden' ? '⭐️' : '☠️';
                       const y =
                         d.sma50 != null && d.sma200 != null
                           ? (d.sma50 + d.sma200) / 2


### PR DESCRIPTION
## Summary
- show death crosses with `☠️` instead of `💀`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6885807ad630832db3aeca3365755a58